### PR TITLE
support return all result at once

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -192,22 +192,29 @@ class ApolloNamespace extends EventEmitter {
       deleted
     } = diff(oldKeys, newKeys)
 
-    unchanged.forEach(key => {
-      const oldValue = this._config[key]
-      const newValue = config[key]
-
-      if (oldValue === newValue) {
-        return
-      }
-
-      this._config[key] = newValue
-
+    if (this.options.entireRes) {
       this.emit('change', {
-        oldValue,
-        newValue,
-        key
+        oldValue: this._config,
+        newValue: config,
       })
-    })
+    } else {
+      unchanged.forEach(key => {
+        const oldValue = this._config[key]
+        const newValue = config[key]
+
+        if (oldValue === newValue) {
+          return
+        }
+
+        this._config[key] = newValue
+
+        this.emit('change', {
+          oldValue,
+          newValue,
+          key
+        })
+      })
+    }
 
     added.forEach(key => {
       const value = config[key]

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -192,7 +192,7 @@ class ApolloNamespace extends EventEmitter {
       deleted
     } = diff(oldKeys, newKeys)
 
-    if (this.options.entireRes) {
+    if (this._options.entireRes) {
       this.emit('change', {
         oldValue: this._config,
         newValue: config,

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -197,6 +197,7 @@ class ApolloNamespace extends EventEmitter {
         oldValue: this._config,
         newValue: config,
       })
+      this._config = config
     } else {
       unchanged.forEach(key => {
         const oldValue = this._config[key]

--- a/src/options.js
+++ b/src/options.js
@@ -73,7 +73,8 @@ const RULES = {
     set: path.resolve
   },
   entireRes: {
-    validate: isBoolean
+    validate: isBoolean,
+    optional: true,
   }
 }
 

--- a/src/options.js
+++ b/src/options.js
@@ -128,7 +128,7 @@ const checkOptions = options => {
     skipInitFetchIfCacheFound = false,
     enableFetch = false,
     cachePath,
-    entireRes,
+    entireRes = false,
   } = options
 
   return ensureType({

--- a/src/options.js
+++ b/src/options.js
@@ -71,6 +71,9 @@ const RULES = {
     validate: isString,
     optional: true,
     set: path.resolve
+  },
+  entireRes: {
+    validate: isBoolean
   }
 }
 
@@ -123,7 +126,8 @@ const checkOptions = options => {
     pollingRetryPolicy = DEFAULT_POLLING_RETRY_POLICY,
     skipInitFetchIfCacheFound = false,
     enableFetch = false,
-    cachePath
+    cachePath,
+    entireRes,
   } = options
 
   return ensureType({
@@ -140,7 +144,8 @@ const checkOptions = options => {
     pollingRetryPolicy,
     skipInitFetchIfCacheFound,
     enableFetch,
-    cachePath
+    cachePath,
+    entireRes
   })
 }
 

--- a/test/integrated.test.js
+++ b/test/integrated.test.js
@@ -199,3 +199,20 @@ test.serial('could enable notification again', async t => {
     app.cluster().enableUpdateNotification(true)
   })
 })
+
+test.serial('suppor return result at once', async t => {
+  baz._options.entireRes = true
+
+  await new Promise(resolve => {
+    baz.once('change', ({
+      newValue,
+    }) => {
+      t.is(baz.get(clusterKey), newValue[clusterKey])
+      t.is(baz.get(clusterKey2), newValue[clusterKey2])
+      resolve()
+    })
+
+    abaz.set(clusterKey, clusterName)
+    .publish()
+  })
+})


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交

### 需求背景
  
> 1. apollo 一个namespce上多个配置，需要一次获取
  
### 实现方案和 API
  
> 1. 参数添加entireRes，用以判断是分批次返回还是一次性返回
  
### 对用户的影响和可能的风险

> 1. 无(默认按照目前的分批次返回)