### PR TITLE
Update fs-extra to version 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "core-util-is": "^1.0.2",
     "diff-sorted-array": "^3.0.0",
     "err-object": "^5.1.4",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.0",
     "request": "^2.88.0"
   }
 }


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps fs-extra to version 9.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***

<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes not automatically fixable by JSFIX.</summary><blockquote class="pr-blockquote">

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* Requires Node.js version 10 or greater
</details>

<details open>
<summary>The following breaking changes are unlikely to affect your code. Below each bullet is listed the dependency usages detected by JSFIX that may be affected by the breaking change.</summary>



* outputJson now outputs objects as they were when the function was called, even if they are mutated later
Suggested fix: You can ignore this breaking change if you don't later modify cacheFile
  - [src/namespace.js#L167-L176](https://github.com/kaelzhang/ctrip-apollo/pull/13/commits/559fa0efb44a11a040ddd39a341530cc98e91df1#diff-a7dd74ceb3e70786b6fc1945e749dd43669c9fa9d147725c8749293ab4c1266bL167-L176)
</details>

</blockquote></details>

</blockquote></details><details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Creating a directory with fs-extra no longer returns the path
* Cannot pass null as an options parameter to *Json* methods
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.